### PR TITLE
Added max length checker for identifier

### DIFF
--- a/file.txt
+++ b/file.txt
@@ -4,7 +4,9 @@ int this_is_some_function() {
     integer_variable = 100 float_variable + 2 - 3 * 4 / 5 % 6;
     (variable + another_variable) / variable * 53.100 + 1234.00;
     char_variable = 'a';
+    string_variable_sting_variable_string_variable = "string";
     integer;
+    string_variable_sting_variable_string_variable = "string";
     return;
     100 "He said \"blah blah\" %d";
     this_a_vari@ble

--- a/scanner.c
+++ b/scanner.c
@@ -216,18 +216,39 @@ void identifier() {
     add_char();
 
     char next_char = get_char();
-    while (isalnum(next_char) || next_char == '_') {  // isalnum checks for letters or digits
+    bool too_long = false;
+
+    while (isalnum(next_char) || next_char == '_') {  // `isalnum` checks for letters or digits
         current_char = next_char;
+
+        // Always add the character to preserve the full lexeme
         add_char();
+
+        // Check if the length exceeds the limit
+        if (lexeme_length > 31) {
+            too_long = true;
+        }
+
         next_char = get_char();
     }
 
     // Put back the last non-alphanumeric character we found
     ungetc(next_char, in_fp);
 
-    // Check if the identifier is a keyword or not 
-    next_token = keywords();
+    // If the identifier is too long, set the token type but delay error reporting
+    if (too_long) {
+        next_token = ERROR_INVALID_IDENTIFIER;
+    } else {
+        // Otherwise, check if the identifier is a keyword
+        next_token = keywords();
+    }
+
+    // Now report errors if needed
+    if (too_long) {
+        printf("ERROR - identifier is too long: %s\n", lexeme);
+    }
 }
+
 
 /******************************************************/
 /* keywords - determine if the identifier is a keyword */

--- a/token.h
+++ b/token.h
@@ -61,5 +61,6 @@ typedef enum
     FALSE,
 
     // Error tokens, not part of the language just for the scanner
-    ERROR_INVALID_CHARACTER
+    ERROR_INVALID_CHARACTER,
+    ERROR_INVALID_IDENTIFIER
 } TokenType;


### PR DESCRIPTION
I made a few additions to the code (although I need clarification on whether it suits your taste or much less follows the requirements you need). 

The output when you have a length of identifier greater than 31 would be like this:

```
ERROR - identifier is too long: string_variable_sting_variable_string_variable
Next token is: 46, Next lexeme is string_variable_sting_variable_string_variable
```

Basically, it shows the error message first (though I reckon na mas okay that the error message will show after the token stream), then proceeds to the token stream entry. 